### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
   ],
   "require": {
     "php": "^8.1",
-    "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-    "illuminate/console": "^9.0|^10.0|^11.0|^12.0"
+    "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+    "illuminate/console": "^9.0|^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "spatie/laravel-data": "^3.0|^4.0",
-    "orchestra/testbench": "^7.0|^8.0|^9.0",
-    "phpunit/phpunit": "^9.5|^10.0|^11.0",
+    "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
     "larastan/larastan": "^3.6",
     "laravel/pint": "^1.18"
   },


### PR DESCRIPTION
## Summary

- Widen `illuminate/support` and `illuminate/console` constraints from `^9.0|^10.0|^11.0|^12.0` to `^9.0|^10.0|^11.0|^12.0|^13.0`
- Add `^10.0|^11.0` to `orchestra/testbench` dev dependency
- Add `^12.0` to `phpunit/phpunit` dev dependency

## Test plan

- [ ] Verify package installs cleanly in a Laravel 13 project
- [ ] Run existing test suite against Laravel 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)